### PR TITLE
fix-end-swap-compute

### DIFF
--- a/v0_5/src/rewards.rs
+++ b/v0_5/src/rewards.rs
@@ -137,8 +137,7 @@ pub trait RewardsModule {
         }
 
         // update delegator rewards based on Active stake
-        let total_active_stake =
-            self.fund_view_module().get_user_stake_of_type(USER_STAKE_TOTALS_ID, FundType::Active);
+        let total_active_stake = self.settings().get_total_delegation_cap();
         let u_stake_active = self.fund_view_module().get_user_stake_of_type(user_id, FundType::Active);
         if u_stake_active > 0 {
             // delegator reward is:

--- a/v0_5/src/user_stake.rs
+++ b/v0_5/src/user_stake.rs
@@ -69,7 +69,8 @@ pub trait UserStakeModule {
         // swap unStaked to deferred payment
         let total_unstaked = self.fund_view_module().get_user_stake_of_type(USER_STAKE_TOTALS_ID, FundType::UnStaked);
         if total_unstaked > 0 {
-            let unstaked_swappable = core::cmp::min(&swappable, &total_unstaked);
+            let all_unstaked = &total_unstaked;
+            let unstaked_swappable = core::cmp::min(&swappable, &all_unstaked);
             let _ = self.fund_transf_module().swap_unstaked_to_deferred_payment(&unstaked_swappable, || false);
         }
 


### PR DESCRIPTION
fix end swap compute - using swap checkpoint
fix computation of rewards according to total-delegation-cap always.